### PR TITLE
Add country options to the registration form

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,11 @@ function App() {
             onChange={(e) => setSelectedCountry(e.target.value)}
           >
             <option value="">Seleccione un país</option>
-            {/* Aquí se deben agregar los options */}
+            <option value="mexico">México</option>
+            <option value="argentina">Argentina</option>
+            <option value="colombia">Colombia</option>
+            <option value="chile">Chile</option>
+            <option value="peru">Perú</option>
           </select>
         </div>
 


### PR DESCRIPTION
This pull request updates the dropdown menu in the `App` component to include specific country options.

* [`src/App.tsx`](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L27-R31): Added options for "México," "Argentina," "Colombia," "Chile," and "Perú" to the dropdown menu in the `App` component.